### PR TITLE
load submodules when cloning the landingzones repo

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -23,6 +23,6 @@ git config --global --add safe.directory /tf/caf/aztfmod
 git config pull.rebase false 
 
 if [ ! -d /tf/caf/landingzones ]; then
-  git clone --branch int-5.6.0 https://github.com/Azure/caf-terraform-landingzones.git /tf/caf/landingzones
+  git clone --recurse-submodules --branch int-5.6.0 https://github.com/Azure/caf-terraform-landingzones.git /tf/caf/landingzones
   sudo chmod +x /tf/caf/landingzones/templates/**/*.sh
 fi


### PR DESCRIPTION
I dont`t know if it important but we use this script in our pipelines and since 2 Days it is not longer possible to load the submodules of aztfmod automatically. 